### PR TITLE
add support for storing a custom keg name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ docker run --rm -it -p 1234:1234 -p 8085:8085 ghcr.io/sklopivo/open-plaato-keg:n
 - **Multi-Architecture Docker Images** - Native support for `linux/amd64` and `linux/arm64` (Raspberry Pi 4/5, Apple Silicon, AWS Graviton)
 
 - **Keg Setup Page (`/setup.html`)** - Full-featured web UI to configure and control your keg:
+  - **Keg Details**: Set custom keg name for easy identification
   - **Units & Mode**: Switch between Metric/US units, Weight/Volume display mode
   - **Scale Sensitivity**: Adjust pour detection sensitivity (4 levels)
   - **Calibration**: Tare scale, set empty keg weight, calibrate with known weight, temperature offset
@@ -27,6 +28,7 @@ docker run --rm -it -p 1234:1234 -p 8085:8085 ghcr.io/sklopivo/open-plaato-keg:n
   - `POST /api/kegs/:id/max-keg-volume` - Set max volume
   - `POST /api/kegs/:id/temperature-offset` - Adjust temperature reading
   - `POST /api/kegs/:id/calibrate-known-weight` - Calibrate with known weight
+  - `POST /api/kegs/:id/keg-name` - Set custom keg name (stored locally)
   - `POST /api/kegs/:id/beer-style` - Set beer style name
   - `POST /api/kegs/:id/date` - Set keg date
   - `POST /api/kegs/:id/og` - Set original gravity (format: 1.xxx)
@@ -40,6 +42,7 @@ docker run --rm -it -p 1234:1234 -p 8085:8085 ghcr.io/sklopivo/open-plaato-keg:n
 
 - **Improved Home Page (`/index.html`)**:
   - Real-time updates via WebSocket
+  - Displays custom keg name prominently when set
   - Shows beer style and keg date as card title
   - Temperature badge, pouring indicator, last pour, remaining percentage
   - Modern dark theme with amber accents
@@ -67,7 +70,7 @@ docker run --rm -it -p 1234:1234 -p 8085:8085 ghcr.io/sklopivo/open-plaato-keg:n
 
 - **CO₂ Mode** - Switch to CO₂ monitoring mode (pins not fully decoded)
 - **Scale Sensitivity** - No read feedback from keg for current setting
-- **Beer Style/Date/OG/FG/ABV** - Stored in local database (keg doesn't echo these values back)
+- **Keg Name/Beer Style/Date/OG/FG/ABV** - Stored in local database (keg doesn't echo these values back)
 
 ## Why this exists?
 
@@ -249,6 +252,7 @@ If Docker isn't your preferred method, you can create an [Elixir Release](https:
         "buff-in": "1024"
       },
       "id": "00000000000000000000000000000001",
+      "my_keg_name": "Garage Keg",
       "my_beer_style": "IPA",
       "my_keg_date": "12.01.2025",
       "my_og": "1.050",
@@ -333,6 +337,7 @@ Showcase how to interact with WebSocket and REST API.
                 "buff-in": "1024"
               },
               "id": "00000000000000000000000000000001",
+              "my_keg_name": "Garage Keg",
               "my_beer_style": "IPA",
               "my_keg_date": "12.01.2025",
               "my_og": "1.050",
@@ -365,6 +370,7 @@ Showcase how to interact with WebSocket and REST API.
     * `min_temperature` / `max_temperature`: Temperature alert thresholds
     * `og` / `fg`: Original and final gravity values (from hardware)
     * `internal`: System info object (dev, ver, fw, build, tmpl, h-beat, buff-in)
+    * `my_keg_name`: User-defined keg name (stored locally)
     * `my_beer_style`: User-defined beer style (stored locally)
     * `my_keg_date`: User-defined keg date (stored locally)
     * `my_og`: User-defined original gravity in format 1.xxx (stored locally)
@@ -414,6 +420,7 @@ Showcase how to interact with WebSocket and REST API.
               "buff-in": "1024"
             },
             "id": "00000000000000000000000000000001",
+            "my_keg_name": "Garage Keg",
             "my_beer_style": "IPA",
             "my_keg_date": "12.01.2025",
             "my_og": "1.050",

--- a/lib/open_plaato_keg/http_router.ex
+++ b/lib/open_plaato_keg/http_router.ex
@@ -147,6 +147,16 @@ defmodule OpenPlaatoKeg.HttpRouter do
   # in our local database. The hardware pins (64, 67) are also updated on the keg,
   # but there is no read feedback from those pins, so we store our own copy.
 
+  post "api/kegs/:id/keg-name" do
+    keg_id = conn.params["id"]
+    %{"value" => value} = conn.body_params
+
+    # Save to our local database only (no hardware pin for this)
+    KegData.publish(keg_id, [{:my_keg_name, value}])
+
+    json_response(conn, 200, %{status: "ok", command: "keg_name", value: value})
+  end
+
   post "api/kegs/:id/beer-style" do
     keg_id = conn.params["id"]
     %{"value" => value} = conn.body_params

--- a/priv/static/index.html
+++ b/priv/static/index.html
@@ -81,6 +81,9 @@
             const lastPour = parseFloat(kegData.last_pour) || 0;
             const isPouring = kegData.is_pouring && kegData.is_pouring !== "0";
 
+            // Get keg name if available
+            const kegName = kegData.my_keg_name?.trim();
+            
             // Build card title from beer style, keg date, and ABV (stored locally as my_beer_style, my_keg_date, my_abv)
             const beerStyle = kegData.my_beer_style?.trim();
             const kegDate = kegData.my_keg_date?.trim();
@@ -107,6 +110,7 @@
                     <div class="card-content">
                         <div class="media">
                             <div class="media-content">
+                                ${kegName ? `<p class="title is-4 has-text-primary" style="margin-bottom: 0.5rem;">${kegName}</p>` : ''}
                                 ${cardTitle ? `<p class="title is-5">${cardTitle}</p>` : ''}
                                 <p class="subtitle is-1">${amountLeft.toFixed(2)} ${volumeUnit}</p>
                             </div>
@@ -135,7 +139,9 @@
             });
 
         // WebSocket connection
-        const socket = new WebSocket('/ws');
+        // Use wss:// for HTTPS, ws:// for HTTP
+        const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const socket = new WebSocket(`${protocol}//${window.location.host}/ws`);
 
         socket.addEventListener('open', (event) => {
             console.log('WebSocket connection opened:', event);

--- a/priv/static/index.html
+++ b/priv/static/index.html
@@ -64,6 +64,29 @@
       }
 
         const kegContainer = document.getElementById('kegContainer');
+        
+        // Store keg data for re-sorting
+        const kegDataMap = new Map();
+        
+        // Sort kegs by name (if present), then by ID
+        function sortKegs(kegs) {
+            return kegs.sort((a, b) => {
+                // Both have names - sort alphabetically by name
+                if (a.my_keg_name && b.my_keg_name) {
+                    return a.my_keg_name.localeCompare(b.my_keg_name);
+                }
+                // Only 'a' has name - 'a' comes first
+                if (a.my_keg_name && !b.my_keg_name) {
+                    return -1;
+                }
+                // Only 'b' has name - 'b' comes first
+                if (!a.my_keg_name && b.my_keg_name) {
+                    return 1;
+                }
+                // Neither has name - sort by ID
+                return a.id.localeCompare(b.id);
+            });
+        }
 
         function createKegCard(kegData) {
             const column = document.createElement('div');
@@ -122,17 +145,30 @@
             return column;
         }
 
+        // Function to render all kegs in sorted order
+        function renderKegs() {
+            kegContainer.innerHTML = '';
+            if (kegDataMap.size === 0) {
+                kegContainer.innerHTML = '<div class="column"><p class="has-text-grey">No kegs found. Connect a keg to see data here.</p></div>';
+            } else {
+                const kegsArray = Array.from(kegDataMap.values());
+                const sortedKegs = sortKegs(kegsArray);
+                sortedKegs.forEach(keg => {
+                    kegContainer.appendChild(createKegCard(keg));
+                });
+            }
+        }
+
         // Fetch initial keg data
         fetch('/api/kegs')
             .then(response => response.json())
             .then(kegs => {
-                if (kegs.length === 0) {
-                    kegContainer.innerHTML = '<div class="column"><p class="has-text-grey">No kegs found. Connect a keg to see data here.</p></div>';
-                } else {
-                    kegs.forEach(keg => {
-                        kegContainer.appendChild(createKegCard(keg));
-                    });
-                }
+                // Store all kegs in the map
+                kegs.forEach(keg => {
+                    kegDataMap.set(keg.id, keg);
+                });
+                // Render them in sorted order
+                renderKegs();
             })
             .catch(err => {
                 kegContainer.innerHTML = '<div class="column"><p class="has-text-danger">Error loading kegs: ' + err.message + '</p></div>';
@@ -149,16 +185,13 @@
 
         socket.addEventListener('message', (event) => {
             const updatedKeg = JSON.parse(event.data);
-            // Find the existing keg card and update its content
             const kegId = updatedKeg.id;
-            const existingCard = document.querySelector(`#kegContainer [data-keg-id="${kegId}"]`);
-            if (existingCard) {
-                const newCard = createKegCard(updatedKeg);
-                existingCard.innerHTML = newCard.querySelector('.card').innerHTML;
-            } else if (kegId) {
-                // New keg appeared, add it
-                kegContainer.appendChild(createKegCard(updatedKeg));
-            }
+            
+            // Update or add the keg in our map
+            kegDataMap.set(kegId, updatedKeg);
+            
+            // Re-render all kegs in sorted order
+            renderKegs();
         });
 
         socket.addEventListener('error', (error) => {

--- a/priv/static/setup.html
+++ b/priv/static/setup.html
@@ -53,6 +53,26 @@
             <p class="help" id="connectionStatus">Loading connected kegs...</p>
           </div>
 
+          <!-- Keg Details Section -->
+          <div class="box section-box">
+            <h2 class="title is-4">Keg Details</h2>
+            
+            <div class="field">
+              <label class="label">Keg Name</label>
+              <p class="help">Give this keg a custom name</p>
+              <div class="control">
+                <div class="field has-addons">
+                  <div class="control is-expanded">
+                    <input class="input" type="text" id="kegName" placeholder="e.g., Garage Keg, Main Tap" />
+                  </div>
+                  <div class="control">
+                    <button class="button is-primary" onclick="sendKegName()">Set</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
           <!-- Units Section -->
           <div class="box section-box">
             <h2 class="title is-4">Units & Mode</h2>
@@ -421,6 +441,11 @@
       }
 
       function populateFormFields(data) {
+        // Keg name (stored locally as my_keg_name) - only update if not focused
+        if (data.my_keg_name) {
+          updateFieldIfNotFocused("kegName", data.my_keg_name.trim());
+        }
+        
         // Temperature offset - only update if not focused
         if (data.temperature_offset) {
           updateFieldIfNotFocused("tempOffset", data.temperature_offset);
@@ -613,6 +638,7 @@
         } else {
           // Clear form when no keg selected
           currentKegData = {};
+          document.getElementById("kegName").value = "";
           document.getElementById("tempOffset").value = "";
           document.getElementById("maxVolume").value = "";
           document.getElementById("beerStyle").value = "";
@@ -773,6 +799,13 @@
         const value = document.getElementById("maxVolume").value;
         if (!value) { showToast("Please enter a volume", "warning"); return; }
         sendCommand("max-keg-volume", { value });
+      }
+
+      // Keg details commands
+      function sendKegName() {
+        const value = document.getElementById("kegName").value;
+        if (!value) { showToast("Please enter a keg name", "warning"); return; }
+        sendCommand("keg-name", { value });
       }
 
       // Beer info commands

--- a/priv/static/setup.html
+++ b/priv/static/setup.html
@@ -376,11 +376,32 @@
       const connectionStatus = document.getElementById("connectionStatus");
       let currentKegData = {};
 
+      // Sort kegs by name (if present), then by ID
+      function sortKegs(kegs) {
+        return kegs.sort((a, b) => {
+          // Both have names - sort alphabetically by name
+          if (a.my_keg_name && b.my_keg_name) {
+            return a.my_keg_name.localeCompare(b.my_keg_name);
+          }
+          // Only 'a' has name - 'a' comes first
+          if (a.my_keg_name && !b.my_keg_name) {
+            return -1;
+          }
+          // Only 'b' has name - 'b' comes first
+          if (!a.my_keg_name && b.my_keg_name) {
+            return 1;
+          }
+          // Neither has name - sort by ID
+          return a.id.localeCompare(b.id);
+        });
+      }
+
       // Load connected kegs
       function loadConnectedKegs() {
         const currentValue = kegIdSelect.value; // Preserve current selection
 
-        fetch("/api/kegs/connected")
+        // Fetch full keg data to get names for display
+        fetch("/api/kegs")
           .then((response) => response.json())
           .then((kegs) => {
             kegIdSelect.innerHTML = '<option value="">Select a connected keg...</option>';
@@ -389,12 +410,16 @@
               connectionStatus.textContent = "No kegs connected";
               connectionStatus.className = "help is-warning";
             } else {
-              kegs.forEach((keg, index) => {
+              // Sort kegs before displaying
+              const sortedKegs = sortKegs(kegs);
+              
+              sortedKegs.forEach((keg, index) => {
                 const option = document.createElement("option");
-                option.value = keg;
-                option.text = keg;
+                option.value = keg.id;
+                // Display ID with name in parentheses if name exists
+                option.text = keg.my_keg_name ? `${keg.id} (${keg.my_keg_name})` : keg.id;
                 // Restore selection or auto-select first keg if none selected
-                if (keg === currentValue || (!currentValue && index === 0)) {
+                if (keg.id === currentValue || (!currentValue && index === 0)) {
                   option.selected = true;
                 }
                 kegIdSelect.appendChild(option);
@@ -403,8 +428,8 @@
               connectionStatus.className = "help is-success";
 
               // Load data for auto-selected keg on first load
-              if (!currentValue && kegs.length > 0) {
-                loadKegData(kegs[0]);
+              if (!currentValue && sortedKegs.length > 0) {
+                loadKegData(sortedKegs[0].id);
               }
             }
           })


### PR DESCRIPTION
This allows optionally setting a name for a keg and then displaying that on the index page and returning in the json data.  The name is returned and the `my_keg_name` key in the json to follow the convention of the `my_` prefix when storing name to the DB that is not propogated or supported on the device.

Also updated the sorting on the index.html page as well as the keg dropdown on the setup.html page to:
- Sorts kegs with names alphabetically by name first
- Places kegs with names before those without
- Sorts kegs without names by their ID