### PR TITLE
Add support for setting a specific empty keg volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,21 @@ docker run --rm -it -p 1234:1234 -p 8085:8085 ghcr.io/sklopivo/open-plaato-keg:n
 - **Multi-Architecture Docker Images** - Native support for `linux/amd64` and `linux/arm64` (Raspberry Pi 4/5, Apple Silicon, AWS Graviton)
 
 - **Keg Setup Page (`/setup.html`)** - Full-featured web UI to configure and control your keg:
+  - **Keg Details**: Set custom keg name for easy identification
   - **Units & Mode**: Switch between Metric/US units, Weight/Volume display mode
   - **Scale Sensitivity**: Adjust pour detection sensitivity (4 levels)
-  - **Calibration**: Tare scale, set empty keg weight, calibrate with known weight, temperature offset
+  - **Calibration**: Tare scale, set empty keg weight (button or specific value), calibrate with known weight, temperature offset
   - **Beer Information**: Set beer style, keg date, OG, FG, ABV calculation, max keg volume (stored locally)
   - **System Status**: View device info, WiFi signal, firmware version, chip temperature, leak detection
 
 - **Keg Command API** - New REST endpoints to send commands to connected kegs:
   - `POST /api/kegs/:id/tare` - Tare the scale
-  - `POST /api/kegs/:id/empty-keg` - Set empty keg weight
+  - `POST /api/kegs/:id/empty-keg` - Set empty keg weight (from current weight)
+  - `POST /api/kegs/:id/set-empty-keg-value` - Set specific empty keg weight value
   - `POST /api/kegs/:id/max-keg-volume` - Set max volume
   - `POST /api/kegs/:id/temperature-offset` - Adjust temperature reading
   - `POST /api/kegs/:id/calibrate-known-weight` - Calibrate with known weight
+  - `POST /api/kegs/:id/keg-name` - Set custom keg name (stored locally)
   - `POST /api/kegs/:id/beer-style` - Set beer style name
   - `POST /api/kegs/:id/date` - Set keg date
   - `POST /api/kegs/:id/og` - Set original gravity (format: 1.xxx)

--- a/lib/open_plaato_keg/http_router.ex
+++ b/lib/open_plaato_keg/http_router.ex
@@ -129,6 +129,16 @@ defmodule OpenPlaatoKeg.HttpRouter do
     end
   end
 
+  post "api/kegs/:id/set-empty-keg-value" do
+    keg_id = conn.params["id"]
+    %{"value" => value} = conn.body_params
+
+    case KegCommander.set_empty_keg_value(keg_id, value) do
+      :ok -> json_response(conn, 200, %{status: "ok", command: "set_empty_keg_value", value: value})
+      {:error, reason} -> json_response(conn, 503, %{error: reason})
+    end
+  end
+
   post "api/kegs/:id/max-keg-volume" do
     keg_id = conn.params["id"]
     %{"value" => value} = conn.body_params

--- a/lib/open_plaato_keg/keg_commander.ex
+++ b/lib/open_plaato_keg/keg_commander.ex
@@ -79,6 +79,7 @@ defmodule OpenPlaatoKeg.KegCommander do
   def tare_release(keg_id), do: send_command(keg_id, :tare, "0")
   def set_empty_keg(keg_id), do: send_command(keg_id, :empty_keg_weight, "1")
   def set_empty_keg_release(keg_id), do: send_command(keg_id, :empty_keg_weight, "0")
+  def set_empty_keg_value(keg_id, value), do: send_command(keg_id, :empty_keg_weight, value)
   def set_max_keg_volume(keg_id, volume), do: send_command(keg_id, :max_keg_volume, volume)
 
   # Monitor commands

--- a/priv/static/setup.html
+++ b/priv/static/setup.html
@@ -147,6 +147,24 @@
             </div>
 
             <div class="field">
+              <label class="label">Set Specific Empty Keg Weight</label>
+              <p class="help">Enter the exact weight of your empty keg</p>
+              <div class="control">
+                <div class="field has-addons">
+                  <div class="control is-expanded">
+                    <input class="input" type="number" id="emptyKegValue" placeholder="e.g., 4.5" step="0.1" />
+                  </div>
+                  <div class="control">
+                    <span class="button is-static" id="emptyKegUnit">kg</span>
+                  </div>
+                  <div class="control">
+                    <button class="button is-primary" onclick="sendEmptyKegValue()">Set Weight</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="field">
               <label class="label">Calibrate with Known Weight</label>
               <p class="help">Place a known weight on the scale for calibration</p>
               <div class="control">
@@ -460,6 +478,17 @@
         if (data.known_weight) {
           updateFieldIfNotFocused("knownWeight", data.known_weight);
         }
+        
+        // Empty keg weight - only update if not focused
+        if (data.empty_keg_weight) {
+          updateFieldIfNotFocused("emptyKegValue", data.empty_keg_weight);
+        }
+        
+        // Update weight unit display based on beer_left_unit
+        const beerLeftUnit = data.beer_left_unit;
+        if (beerLeftUnit === "lbs" || beerLeftUnit === "kg") {
+          document.getElementById("emptyKegUnit").textContent = beerLeftUnit;
+        }
       }
 
       function updateSettingsDisplay(data) {
@@ -615,6 +644,7 @@
           currentKegData = {};
           document.getElementById("tempOffset").value = "";
           document.getElementById("maxVolume").value = "";
+          document.getElementById("emptyKegValue").value = "";
           document.getElementById("beerStyle").value = "";
           document.getElementById("kegDate").value = "";
           document.getElementById("og").value = "";
@@ -760,6 +790,12 @@
         const value = document.getElementById("knownWeight").value;
         if (!value) { showToast("Please enter a weight value", "warning"); return; }
         sendCommand("calibrate-known-weight", { value });
+      }
+
+      function sendEmptyKegValue() {
+        const value = document.getElementById("emptyKegValue").value;
+        if (!value) { showToast("Please enter an empty keg weight", "warning"); return; }
+        sendCommand("set-empty-keg-value", { value });
       }
 
       function sendTempOffset() {


### PR DESCRIPTION
Added the ability set a specific empty keg volume.  This matches the previous fucntionality from the plaato IOS app.  This is helpful when you dont have the empty keg available any longer (for instance, the keg is full) but you need to reset the empty keg value so the calculations are correct