### PR TITLE
Add connected status to kegs api details

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ If Docker isn't your preferred method, you can create an [Elixir Release](https:
         "buff-in": "1024"
       },
       "id": "00000000000000000000000000000001",
+      "connected": true,
       "my_beer_style": "IPA",
       "my_keg_date": "12.01.2025",
       "my_og": "1.050",
@@ -333,6 +334,7 @@ Showcase how to interact with WebSocket and REST API.
                 "buff-in": "1024"
               },
               "id": "00000000000000000000000000000001",
+              "connected": true,
               "my_beer_style": "IPA",
               "my_keg_date": "12.01.2025",
               "my_og": "1.050",
@@ -343,6 +345,7 @@ Showcase how to interact with WebSocket and REST API.
       ```
 * **Fields in Response:**
     * `id`: Unique identifier for the keg (32-character hex string from auth token)
+    * `connected`: Boolean indicating if the keg is currently connected
     * `amount_left`: Current amount of beer left in the keg
     * `percent_of_beer_left`: Percentage of beer remaining (0-100)
     * `max_keg_volume`: Maximum keg volume
@@ -414,6 +417,7 @@ Showcase how to interact with WebSocket and REST API.
               "buff-in": "1024"
             },
             "id": "00000000000000000000000000000001",
+            "connected": true,
             "my_beer_style": "IPA",
             "my_keg_date": "12.01.2025",
             "my_og": "1.050",

--- a/lib/open_plaato_keg/http_router.ex
+++ b/lib/open_plaato_keg/http_router.ex
@@ -38,7 +38,13 @@ defmodule OpenPlaatoKeg.HttpRouter do
   end
 
   get "api/kegs" do
-    data = KegData.all()
+    connected_kegs = KegCommander.connected_kegs()
+    
+    data = 
+      KegData.all()
+      |> Enum.map(fn keg ->
+        Map.put(keg, :connected, keg.id in connected_kegs)
+      end)
 
     conn
     |> put_resp_content_type("application/json")
@@ -46,11 +52,16 @@ defmodule OpenPlaatoKeg.HttpRouter do
   end
 
   get "api/kegs/:id" do
-    case KegData.get(conn.params["id"]) do
+    keg_id = conn.params["id"]
+    
+    case KegData.get(keg_id) do
       %{} = data when map_size(data) > 0 ->
+        connected_kegs = KegCommander.connected_kegs()
+        data_with_connected = Map.put(data, :connected, keg_id in connected_kegs)
+        
         conn
         |> put_resp_content_type("application/json")
-        |> send_resp(200, Poison.encode!(data))
+        |> send_resp(200, Poison.encode!(data_with_connected))
 
       _ ->
         conn

--- a/priv/static/index.html
+++ b/priv/static/index.html
@@ -80,6 +80,7 @@
 
             const lastPour = parseFloat(kegData.last_pour) || 0;
             const isPouring = kegData.is_pouring && kegData.is_pouring !== "0";
+            const isConnected = kegData.connected === true || kegData.connected === "true";
 
             // Build card title from beer style, keg date, and ABV (stored locally as my_beer_style, my_keg_date, my_abv)
             const beerStyle = kegData.my_beer_style?.trim();
@@ -101,6 +102,9 @@
             const card = `
                 <div class="card" data-keg-id="${kegData.id}">
                     <span class="temperature-badge">${!isNaN(temperature) ? temperature.toFixed(1) : '--'}${tempUnit}</span>
+                    <span class="icon wifi-indicator ${isConnected ? 'is-connected' : 'is-disconnected'}" title="${isConnected ? 'Connected' : 'Disconnected'}">
+                        ${isConnected ? '📶' : '&nbsp;'}
+                    </span>
                     <span class="pouring-indicator ${isPouring ? 'is-pouring' : ''}" title="${isPouring ? 'POURING' : ''}"></span>
                     ${lastPour > 0 ? `<span class="last-pour-badge">LAST POUR: ${lastPour.toFixed(2)} ${volumeUnit}</span>` : ''}
                     <span class="remaining-badge">REMAINING: ${percentLeft.toFixed(1)}%</span>

--- a/priv/static/style.css
+++ b/priv/static/style.css
@@ -679,6 +679,24 @@ body {
   z-index: 1;
 }
 
+/* WiFi connection indicator */
+.wifi-indicator {
+  position: absolute;
+  top: 8px;
+  right: 35px;
+  font-size: 1rem;
+  z-index: 10;
+}
+
+.wifi-indicator.is-connected {
+  opacity: 1;
+}
+
+.wifi-indicator.is-disconnected {
+  opacity: 0.5;
+  filter: grayscale(100%);
+}
+
 /* Pouring indicator */
 .pouring-indicator {
   position: absolute;


### PR DESCRIPTION
This adds a "connected" field to the kegs JSON that checks if the kegs id is in the KegCommander.get_connected() list.  Also added a indicator to the top right of the Keg card in the index.html page 
<img width="919" height="373" alt="Screenshot 2026-02-19 at 9 08 04 AM" src="https://github.com/user-attachments/assets/b48f7d7f-bffd-48f8-9bff-da7db262e9de" />
