### PR TITLE
Fix WebSocket protocol for HTTPS reverse proxy

### DIFF
--- a/priv/static/setup.html
+++ b/priv/static/setup.html
@@ -627,7 +627,8 @@
       });
 
       // WebSocket connection for real-time updates
-      const socket = new WebSocket(`ws://${window.location.host}/ws`);
+      const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+      const socket = new WebSocket(`${wsProtocol}//${window.location.host}/ws`);
 
       socket.addEventListener("open", () => {
         console.log("WebSocket connected for setup page");


### PR DESCRIPTION
## Summary

- `setup.html` hardcodes `ws://` for the WebSocket connection, which causes a `Mixed Content` error when served behind an HTTPS reverse proxy (the browser blocks insecure WebSocket connections from HTTPS pages)
- Detects the page protocol and uses `wss://` when loaded over HTTPS
- `index.html` already works correctly because it uses a relative `/ws` path

## Browser error before fix

```
Mixed Content: The page at 'https://...' was loaded over HTTPS, but attempted
to connect to the insecure WebSocket endpoint 'ws://.../ws'. This request has
been blocked; this endpoint must be available over WSS.
```

This caused the setup page to be stuck on "Loading connected kegs..." since the WebSocket never connects.